### PR TITLE
remove chemprop website; replace AICures website with archived version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Data and scripts for COVID-19
 
-This GitHub repo contains data and scripts relevant to COVID-19, which is the disease caused by the virus SARS-CoV-2. For a full descriptions of our efforts, please see https://www.aicures.mit.edu/.
+This GitHub repo contains data and scripts relevant to COVID-19, which is the disease caused by the virus SARS-CoV-2. For a full descriptions of our efforts, please see [https://www.aicures.mit.edu/](https://web.archive.org/web/20220812054522/https://www.aicures.mit.edu/).
 
 Note that since relatively little data for SARS-CoV-2 is available, most of the data in this repo is for SARS-CoV (responsible for the 2002/3 [SARS](https://en.wikipedia.org/wiki/Severe_acute_respiratory_syndrome) outbreak) and other related coronaviruses. The hope is that models trained on this data will be able to retain their predictive ability on SARS-CoV-2.
 
-Although the data contained in this repo can be used by any model, we have primarily been working with the message passing neural network model [chemprop](https://github.com/chemprop/chemprop). Our trained models are available on http://chemprop.csail.mit.edu/predict and the predictions from these models on the [Broad Repurposing Hub](https://www.broadinstitute.org/drug-repurposing-hub) are available in [predictions/](https://github.com/yangkevin2/coronavirus_data/tree/master/predictions).
+Although the data contained in this repo can be used by any model, we have primarily been working with the message passing neural network model [chemprop](https://github.com/chemprop/chemprop). The predictions from these models on the [Broad Repurposing Hub](https://www.broadinstitute.org/drug-repurposing-hub) are available in [predictions/](https://github.com/yangkevin2/coronavirus_data/tree/master/predictions).
 
 ## [data/](https://github.com/yangkevin2/coronavirus_data/tree/master/data)
 


### PR DESCRIPTION
Removing the chemprop website from the README since these trained models will no longer be available there and the website will be taken down (per discussion in https://github.com/chemprop/chemprop/issues/515 and https://github.com/chemprop/chemprop/issues/518). 

Also replaced the link to the MIT AICures website with the archived version since the site appears to no longer be online.